### PR TITLE
Restrict dependabot to specific dependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
     reviewers:
       - "sleberknight"
       - "chrisrohr"
+    allow:
+      - dependency-name: "io.kiwiproject:*"
+      - dependency-name: "io.dropwizard:*"
+      - dependency-name: "org.projectlombok:lombok"
+      - dependency-name: "org.assertj:assertj-core"
+      - dependency-name: "org.junit.jupiter:*"
+      - dependency-name: "org.mockito:mockito-core"


### PR DESCRIPTION
* kiwiproject (any)
* dropwizard (any)
* lombok
* assertj-core
* junit jupiter (any)
* mockito-core