### PR TITLE
Extract test helper methods into LogstashContainerExtension

### DIFF
--- a/src/test/java/org/kiwiproject/elk/AbstractElkAppenderIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/AbstractElkAppenderIntegrationTest.java
@@ -2,8 +2,6 @@ package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
-
 import lombok.extern.slf4j.Slf4j;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
 import org.junit.jupiter.api.Test;
@@ -80,11 +78,7 @@ abstract class AbstractElkAppenderIntegrationTest {
         logstash().awaitLogContains(germanHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(germanHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(germanHello);
 
         var fieldNames = fieldNames();
 

--- a/src/test/java/org/kiwiproject/elk/ElkAppenderCallerDataIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderCallerDataIntegrationTest.java
@@ -2,8 +2,6 @@ package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,11 +38,7 @@ class ElkAppenderCallerDataIntegrationTest extends AbstractElkAppenderIntegratio
         logstash().awaitLogContains(danishHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(danishHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(danishHello);
 
         assertAll(
                 () -> assertThat(helloLog).containsEntry("caller_class_name", ElkAppenderCallerDataIntegrationTest.class.getName()),

--- a/src/test/java/org/kiwiproject/elk/ElkAppenderContextsIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderContextsIntegrationTest.java
@@ -2,8 +2,6 @@ package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
-
 import ch.qos.logback.classic.LoggerContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -64,11 +62,7 @@ class ElkAppenderContextsIntegrationTest extends AbstractElkAppenderIntegrationT
         logstash().awaitLogContains(dutchHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(dutchHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(dutchHello);
 
         assertAll(
                 () -> assertThat(helloLog).containsEntry("organization", "kiwiproject"),
@@ -92,11 +86,7 @@ class ElkAppenderContextsIntegrationTest extends AbstractElkAppenderIntegrationT
         logstash().awaitLogContains(frenchHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(frenchHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(frenchHello);
 
         assertAll(
                 () -> assertThat(helloLog).containsEntry("traceId", traceId),

--- a/src/test/java/org/kiwiproject/elk/ElkAppenderCustomFieldsIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderCustomFieldsIntegrationTest.java
@@ -2,8 +2,6 @@ package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,11 +48,7 @@ class ElkAppenderCustomFieldsIntegrationTest extends AbstractElkAppenderIntegrat
         logstash().awaitLogContains(italianHello);
 
          // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(italianHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(italianHello);
 
          assertAll(
                 () -> assertThat(KiwiMaps.getAsStringOrNull(helloLog, "application")).isEqualTo("order-service"),

--- a/src/test/java/org/kiwiproject/elk/ElkAppenderIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderIntegrationTest.java
@@ -1,8 +1,6 @@
 package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,11 +40,7 @@ class ElkAppenderIntegrationTest extends AbstractElkAppenderIntegrationTest {
         logstash().awaitLogContains(klingonHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(klingonHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(klingonHello);
 
         System.out.println("helloLog = " + helloLog);
 

--- a/src/test/java/org/kiwiproject/elk/ElkAppenderNoContextsIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderNoContextsIntegrationTest.java
@@ -2,8 +2,6 @@ package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
-
 import ch.qos.logback.classic.LoggerContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -64,11 +62,7 @@ class ElkAppenderNoContextsIntegrationTest extends AbstractElkAppenderIntegratio
         logstash().awaitLogContains(portugueseHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(portugueseHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(portugueseHello);
 
         assertAll(
                 () -> assertThat(helloLog).doesNotContainKey("organization"),
@@ -92,11 +86,7 @@ class ElkAppenderNoContextsIntegrationTest extends AbstractElkAppenderIntegratio
         logstash().awaitLogContains(swedishHello);
 
         // Verify details of the log message
-        var helloLog = logstash().logs().lines()
-                .filter(line -> line.contains(swedishHello))
-                .map(JSON_HELPER::toMap)
-                .findFirst()
-                .orElseThrow();
+        var helloLog = logstash().findUniqueLogEntryContaining(swedishHello);
 
         assertAll(
                 () -> assertThat(helloLog).doesNotContainKey("traceId"),


### PR DESCRIPTION
* Extract awaitLogContains test helper methods; use in tests to replace duplicated code
* Extract findUniqueLogEntryContaining and helper findLogEntriesContaining methods
  from duplicate code in tests.
* Change execInContainer method to catch IOException and re-throw as an UncheckedIOException.
  UnsupportedOperationException is a runtime exception so there's no need to catch it and
  wrap with a RuntimeException.