### PR TITLE
ElkAppenderFullIntegrationTest: don't require value for system property

### DIFF
--- a/src/test/java/org/kiwiproject/elk/ElkAppenderFullIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderFullIntegrationTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@EnabledIfSystemProperty(named = "fullIntegrationTests", matches = "true")
+@EnabledIfSystemProperty(named = "fullIntegrationTests", matches = ".*")
 @DisplayName("ElkAppender TCP (using Logstash in container)")
 @Slf4j
 class ElkAppenderFullIntegrationTest extends AbstractElkAppenderIntegrationTest {


### PR DESCRIPTION
It is annoying to have to do -DfullIntegrationTests=true so change the regex in the EnabledIfSystemProperty annotation to any value. This lets you just do: mvn test -DfullIntegrationTests

(Yes, someone could also do  -DfullIntegrationTests=false and they would be included, but whatever...)