### PR TITLE
Add EnabledForFullIntegrationTests meta-annotation

### DIFF
--- a/src/test/java/org/kiwiproject/elk/ElkAppenderFullIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderFullIntegrationTest.java
@@ -2,10 +2,9 @@ package org.kiwiproject.elk;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@EnabledIfSystemProperty(named = "fullIntegrationTests", matches = ".*")
+@EnabledForFullIntegrationTests
 @DisplayName("ElkAppender TCP (using Logstash in container)")
 @Slf4j
 class ElkAppenderFullIntegrationTest extends AbstractElkAppenderIntegrationTest {

--- a/src/test/java/org/kiwiproject/elk/EnabledForFullIntegrationTests.java
+++ b/src/test/java/org/kiwiproject/elk/EnabledForFullIntegrationTests.java
@@ -1,0 +1,22 @@
+package org.kiwiproject.elk;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enables a JUnit Jupiter test class or method only when the
+ * {@code fullIntegrationTests} system property is defined.
+ * Note that there doesn't need to be a value, and if there is
+ * a value, it doesn't matter what it is.
+ * <p>
+ * You can run integration tests like: {@code mvn test -DfullIntegrationTests}
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIfSystemProperty(named = "fullIntegrationTests", matches = ".*")
+public @interface EnabledForFullIntegrationTests {
+}


### PR DESCRIPTION
While there's only one full integration test now, I might add more later (e..g., if I can get one working for UDP). Plus, annotating the full integration test classes with @EnabledForFullIntegrationTests is nicer in addition to reducing duplication.