### PR TITLE
Rename argument in ElkAppenderFactory#build to match superclass method

### DIFF
--- a/src/main/java/org/kiwiproject/elk/ElkAppenderFactory.java
+++ b/src/main/java/org/kiwiproject/elk/ElkAppenderFactory.java
@@ -41,7 +41,7 @@ public class ElkAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
 
     @Override
     public Appender<ILoggingEvent> build(LoggerContext loggerContext,
-                                         String s,
+                                         String applicationName,
                                          LayoutFactory<ILoggingEvent> layoutFactory,
                                          LevelFilterFactory<ILoggingEvent> levelFilterFactory,
                                          AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory) {


### PR DESCRIPTION
Rename the 's' argument to 'applicationName' in ElkAppenderFactory#build to match the corresponding argument in its superclass AppenderFactory. Also, because 's' is a useless argument name...