### PR TITLE
Add guava and jackson-annotations dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,16 @@
             <artifactId>kiwi</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>


### PR DESCRIPTION
Since these are directly used in ElkAppenderFactory, they should be declared as top-level required dependencies.