### PR TITLE
Add Javadocs to ElkAppenderFactory; add explicit no-args constructor

### DIFF
--- a/src/test/java/org/kiwiproject/elk/ElkAppenderFactoryTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderFactoryTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -37,6 +38,25 @@ class ElkAppenderFactoryTest {
         loggerContext = new LoggerContext();
         filterFactory = new ThresholdLevelFilterFactory();
         appenderFactory = new AsyncLoggingEventAppenderFactory();
+    }
+
+    @Nested
+    class Constructor {
+
+        @Test
+        void shouldSetDefaultValues() {
+            var factory = new ElkAppenderFactory();
+
+            assertAll(
+                () -> assertThat(factory.isUseUdp()).isFalse(),
+                () -> assertThat(factory.isIncludeCallerData()).isFalse(),
+                () -> assertThat(factory.isIncludeContext()).isTrue(),
+                () -> assertThat(factory.isIncludeMdc()).isTrue(),
+                () -> assertThat(factory.getCustomFields()).isEmpty(),
+                () -> assertThat(factory.getFieldNames()).isEmpty(),
+                () -> assertThat(factory.getElkLoggerConfigProvider()).isNotNull()
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
* Add class-level Javadocs to ElkAppenderFactory
* Add a no-args constructor and move all field initialization in there. I did this mainly for readability; you can easily see all the default values in the same place. Another reason is that you can easily breakpoint inside the constructor during debugging.
* Add a test to verify the default values. To accomodate this, I added package-private getter methods. The exception is includeCallerData, because it overrides the superclass method.
* Don't allow setting the ElkLoggerConfigProvider. Had to add a Setter annotation with AccessLevel.NONE since there is a class-level Setter which generates setters for all fields.

Closes #310
Closes #311