### PR TITLE
Add support for configuring host and port in ElkAppenderFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,26 @@ Add to your Dropwizard configuration:
         - type: elk
 ```
 
-The connection details of the Logstash server must be set, _but this cannot be done
-directly in the Dropwizard configuration._
-
-To set the host and port of the Logstash server, as well as custom fields, you can use system
-properties, environment variables, or a configuration file as defined by
+The connection details of the Logstash server must be set, and can be done by
+manually configuring `host` and `port` or by using values provided by
 [ElkLoggerConfigProvider](https://javadoc.io/doc/org.kiwiproject/dropwizard-config-providers/latest/org/kiwiproject/config/provider/ElkLoggerConfigProvider.html).
 
-The custom fields must be JSON, for example:
+The `customFields` property will send custom fields with every log message.
+Common things to send are service name, version, deployment environment, etc.
+These can either be explicitly configured or provided by `ElkLoggerConfigProvider`.
+Entries with blank keys or values are ignored when generating custom fields JSON.
+
+When many services all send data to the same Logstash server, it's generally
+preferred to configure using  `ElkLoggerConfigProvider` to avoid duplicating
+configuration in every service.
+
+If you are relying on `ElkLoggerConfigProvider` to provide values for `host`,
+`port`, and optionally `customFields`, you can use system properties, environment variables,
+or a configuration file. See the `ElkLoggerConfigProvider`
+[documentation](https://javadoc.io/doc/org.kiwiproject/dropwizard-config-providers/latest/org/kiwiproject/config/provider/ElkLoggerConfigProvider.html)
+for details.
+
+However configured, the custom fields must be JSON, for example:
 
 ```json
 { "serviceName": "invoice-service", "serviceHost": "dev-svc-1.acme.com", "serviceEnvironment": "dev" }
@@ -81,13 +93,16 @@ java -jar /opt/service/invoice-service/service.jar server /opt/service/invoice-s
 
 The properties that can be set in the Dropwizard configuration are:
 
-| Property Name     | Default | Description                                                         |
-|-------------------|---------|---------------------------------------------------------------------|
-| includeCallerData | false   | Whether the caller data is included in the message to logstash      |
-| includeContext    | true    | Whether to include the logging context in the message to logstash   |
-| includeMdc        | true    | Whether to include the MDC in the message to logstash               |
-| fieldNames        | empty   | Map of Logstash field name mappings if overrides are needed         |
-| useUdp            | false   | Whether to use UDP instead of the default TCP for connections       |
+| Property Name     | Default | Description                                                                                                                                                                                |
+|-------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| host              | null    | The logstash host. If not provided, fall back to ElkLoggerConfigProvider.                                                                                                                  |
+| port              | null    | The logstash port. If not provided, fall back to ElkLoggerConfigProvider.                                                                                                                  |                                                         |
+| includeCallerData | false   | Whether the caller data is included in the message to logstash                                                                                                                             |
+| includeContext    | true    | Whether to include the logging context in the message to logstash                                                                                                                          |
+| includeMdc        | true    | Whether to include the MDC in the message to logstash                                                                                                                                      |
+| fieldNames        | empty   | Map of Logstash field name mappings if overrides are needed                                                                                                                                |
+| customFields      | empty   | Custom fields to send in the message to logstash. If not provided, fall back to ElkLoggerConfigProvider. Entries with blank keys or values are ignored when generating custom fields JSON. |
+| useUdp            | false   | Whether to use UDP instead of the default TCP for connections                                                                                                                              |
 
 Below is a custom configuration that does not include the [logging context](https://logback.qos.ch/manual/architecture.html#LoggerContext)
 or the [MDC](https://logback.qos.ch/manual/mdc.html).

--- a/src/test/java/org/kiwiproject/elk/ElkAppenderFactoryTest.java
+++ b/src/test/java/org/kiwiproject/elk/ElkAppenderFactoryTest.java
@@ -1,11 +1,18 @@
 package org.kiwiproject.elk;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.kiwiproject.test.assertj.KiwiAssertJ.assertIsExactType;
+import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
 
+import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.AsyncAppenderBase;
 import io.dropwizard.logging.common.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.common.filter.ThresholdLevelFilterFactory;
@@ -18,10 +25,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.junitpioneer.jupiter.SetSystemProperty;
+import org.kiwiproject.collect.KiwiMaps;
 import org.kiwiproject.config.provider.ResolvedBy;
 import org.kiwiproject.elk.LogstashContainerExtension.LogstashContainerType;
 
+import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Map;
 
 @DisplayName("ElkAppenderFactory")
@@ -98,6 +113,185 @@ class ElkAppenderFactoryTest {
                     null,
                     filterFactory,
                     appenderFactory);
+        }
+    }
+
+    @Nested
+    @SetSystemProperty(key = "kiwi.elk.host", value = "localhost")
+    @SetSystemProperty(key = "kiwi.elk.port", value = "5044")
+    @SetSystemProperty(
+            key = "kiwi.elk.customFields",
+            value = """
+                    {
+                        "serviceName": "default-service",
+                        "serviceHost": "localhost",
+                        "serviceEnvironment": "local"
+                    }
+                    """
+    )
+    class WithSettingsOnFactory {
+
+        @Test
+        void shouldUseHostAndPortFromFactory() {
+            var factory = new ElkAppenderFactory();
+            var host = "dev-log-1.example.com";
+            var port = 57_003;
+            factory.setHost(host);
+            factory.setPort(port);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var destinations = getLogstashAppenderDestinations(appender);
+            assertThat(destinations)
+                    .describedAs("should use host and port from ElkAppenderFactory")
+                    .extracting(InetSocketAddress::getHostName, InetSocketAddress::getPort)
+                    .containsExactly(tuple(host, port));
+        }
+
+        @Test
+        void shouldUseHostFromFactory_AndFallbackToProviderForPort() {
+            var factory = new ElkAppenderFactory();
+            var host = "dev-log-1.example.com";
+            factory.setHost(host);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var destinations = getLogstashAppenderDestinations(appender);
+            assertThat(destinations)
+                    .describedAs("should use host from ElkAppenderFactory, port from system property")
+                    .extracting(InetSocketAddress::getHostName, InetSocketAddress::getPort)
+                    .containsExactly(tuple(host, 5044));
+        }
+
+        @Test
+        void shouldUsePortFromFactory_AndFallbackToProvidedHost() {
+            var factory = new ElkAppenderFactory();
+            var port = 37_003;
+            factory.setPort(port);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var destinations = getLogstashAppenderDestinations(appender);
+            assertThat(destinations)
+                    .describedAs("should use host from system property, port from ElkAppenderFactory")
+                    .extracting(InetSocketAddress::getHostName, InetSocketAddress::getPort)
+                    .containsExactly(tuple("localhost", port));
+        }
+
+        @Test
+        void shouldUseCustomFields_FromFactory() {
+            var factory = new ElkAppenderFactory();
+            var customFields = Map.of(
+                    "serviceName", "invoice-service",
+                    "serviceEnvironment", "dev"
+            );
+            factory.setCustomFields(customFields);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var encoderCustomFields = extractEncoderCustomFields(appender);
+            assertThat(encoderCustomFields).isEqualTo(customFields);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldHandleNullOrEmptyCustomFieldsOnFactory_AndFallbackToProvidedValues(Map<String, String> customFields) {
+            var factory = new ElkAppenderFactory();
+            factory.setCustomFields(customFields);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var encoderCustomFields = extractEncoderCustomFields(appender);
+            var providerCustomFields = JSON_HELPER.toMap(System.getProperty("kiwi.elk.customFields"));
+            assertThat(encoderCustomFields).isEqualTo(providerCustomFields);
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                serviceEnvironment, null
+                serviceEnvironment, ''
+                null, dev
+                '', dev
+                """, nullValues = "null")
+        void shouldFilterOutCustomFieldEntries_HavingBlankKeyOrValue(String key, String value) {
+            var customFields = KiwiMaps.<String, String>newHashMap(
+                    "serviceName", "test-service",
+                    "serviceVersion", "1.0.0",
+                    key, value
+            );
+
+            var factory = new ElkAppenderFactory();
+            factory.setCustomFields(customFields);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var encoderCustomFields = extractEncoderCustomFields(appender);
+            assertThat(encoderCustomFields).containsOnly(
+                    entry("serviceName", "test-service"),
+                    entry("serviceVersion", "1.0.0")
+            );
+        }
+
+        @Test
+        void shouldNotSetCustomFields_WhenAllAreFilteredOut() {
+            var customFields = KiwiMaps.<String, String>newHashMap(
+                    "serviceName", null,
+                    "serviceVersion", "",
+                    "serviceEnvironment", " "
+            );
+
+            var factory = new ElkAppenderFactory();
+            factory.setCustomFields(customFields);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var encoderCustomFields = extractEncoderCustomFields(appender);
+            assertThat(encoderCustomFields)
+                    .describedAs("Custom fields should not be set when all are filtered out")
+                    .isNull();
+        }
+
+        @Test
+        @ClearSystemProperty(key = "kiwi.elk.customFields")
+            // note: clearing the property set above
+        void shouldIgnoreNullCustomFieldsOnFactory_WhenCustomFieldsNotProvided() {
+            var factory = new ElkAppenderFactory();
+            factory.setCustomFields(null);
+
+            var appender = factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory);
+
+            var encoderCustomFields = extractEncoderCustomFields(appender);
+            assertThat(encoderCustomFields).isNull();
+        }
+
+        private static Map<String, Object> extractEncoderCustomFields(Appender<ILoggingEvent> appender) {
+            var logstashTcpAppender = getLogstashTcpSocketAppender(appender);
+            var logstashEncoder = assertIsExactType(logstashTcpAppender.getEncoder(), LogstashEncoder.class);
+
+            var customFieldsJson = logstashEncoder.getCustomFields();
+            return JSON_HELPER.toMap(customFieldsJson);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { -2, -1, 0, 65_536 })
+        void shouldThrowIllegalState_WhenPortIsInvalid(int port) {
+            var factory = new ElkAppenderFactory();
+            factory.setPort(port);
+
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> factory.build(loggerContext, APP_NAME, null, filterFactory, appenderFactory))
+                    .withMessage("port %d is not a valid port (must be in range 1-65535)", port);
+        }
+
+        private static List<InetSocketAddress> getLogstashAppenderDestinations(Appender<ILoggingEvent> appender) {
+            var logstashTcpAppender = getLogstashTcpSocketAppender(appender);
+            return logstashTcpAppender.getDestinations();
+        }
+
+        private static LogstashTcpSocketAppender getLogstashTcpSocketAppender(Appender<ILoggingEvent> appender) {
+            var asyncAppender = assertIsExactType(appender, AsyncAppender.class);
+            var loggingEventAppender = asyncAppender.iteratorForAppenders().next();
+            return assertIsExactType(loggingEventAppender, LogstashTcpSocketAppender.class);
         }
     }
 


### PR DESCRIPTION
* Allow host and port to be set directly or resolved via ElkLoggerConfigProvider.
* Add validation for invalid port numbers and missing resolution.
* Filter out entries with blank keys or values before serializing JSON.
* Skip setting custom fields when none remain after filtering.
* Update README with host/port configuration details and note on ignored blank entries.
* Update Javadoc in ElkAppenderFactory to include host/port.

Closes #308
Closes #314