### PR TITLE
Add dependabot for Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,16 @@ updates:
       - "sleberknight"
       - "chrisrohr"
 
+  # Docker image tracking (for test containers)
+  - package-ecosystem: "docker"
+    directory: "/dependabot-images"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "docker.elastic.co/logstash/logstash"
+      - dependency-name: "toolbelt/netcat"
+    groups:
+      elk-stack:
+        patterns:
+          - "docker.elastic.co/logstash/logstash"
+          - "toolbelt/netcat"

--- a/dependabot-images/Dockerfile.logstash
+++ b/dependabot-images/Dockerfile.logstash
@@ -1,0 +1,2 @@
+# Dummy file for Dependabot image tracking
+FROM docker.elastic.co/logstash/logstash:9.2.0

--- a/dependabot-images/Dockerfile.netcat
+++ b/dependabot-images/Dockerfile.netcat
@@ -1,0 +1,2 @@
+# Dummy file for Dependabot image tracking
+FROM toolbelt/netcat:1.13.0


### PR DESCRIPTION
This is to get updated when new images are published.

Relates to #316