### PR TITLE
Remove jackson-bom since now managed by kiwi-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <properties>
         <!-- Versions for required dependencies -->
         <dropwizard-config-providers.version>3.0.3</dropwizard-config-providers.version>
-        <jackson3.version>3.1.4</jackson3.version>
         <kiwi.version>5.4.0</kiwi.version>
         <kiwi-test.version>4.2.0</kiwi-test.version>
         <kiwi-bom.version>3.3.0</kiwi-bom.version>
@@ -45,14 +44,6 @@
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>kiwi-bom</artifactId>
                 <version>${kiwi-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>tools.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
kiwi-bom 3.3.0 now manages versions of both Jackson 2 and 3, so we can remove it here.

Closes #376