### PR TITLE
chore(deps): manually bump docker images pending Dependabot fix

### DIFF
--- a/.github/dependabot-images/Dockerfile.logstash
+++ b/.github/dependabot-images/Dockerfile.logstash
@@ -1,2 +1,2 @@
 # Dummy file for Dependabot image tracking
-FROM docker.elastic.co/logstash/logstash:9.4.1
+FROM docker.elastic.co/logstash/logstash:9.4.3

--- a/.github/dependabot-images/Dockerfile.netcat
+++ b/.github/dependabot-images/Dockerfile.netcat
@@ -1,2 +1,2 @@
 # Dummy file for Dependabot image tracking
-FROM toolbelt/netcat:2026-04-23
+FROM toolbelt/netcat:2026-06-23


### PR DESCRIPTION
## Summary
- Bump `docker.elastic.co/logstash/logstash` from `9.4.1` to `9.4.3`
- Bump `toolbelt/netcat` from `2026-04-23` to `2026-06-23`

Dependabot itself has been unable to open PRs for these since mid-May due to a hosted-service-side bug rejecting `create_pull_request` for this ecosystem (`400: The request contains invalid or unauthorized changes`), matching [dependabot/dependabot-core#11320](https://github.com/dependabot/dependabot-core/issues/11320). We confirmed both are the latest available versions via Dependabot's own version resolution in the manually-triggered job logs, and independently via Docker Hub / Elastic release notes. Applying the bumps by hand in the meantime.

## Test plan
- [x] `mvn compile test-compile` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_016kYTgnERK2gEn7F35cUEQp)_